### PR TITLE
Fail build on rule violation

### DIFF
--- a/src/main/java/de/kontext_e/jqassistant/gradle/JqassistantExecutor.java
+++ b/src/main/java/de/kontext_e/jqassistant/gradle/JqassistantExecutor.java
@@ -1,6 +1,7 @@
 package de.kontext_e.jqassistant.gradle;
 
 import com.buschmais.jqassistant.commandline.CliExecutionException;
+import com.buschmais.jqassistant.commandline.CliRuleViolationException;
 import com.buschmais.jqassistant.commandline.Main;
 import com.buschmais.jqassistant.commandline.Task;
 import com.buschmais.jqassistant.commandline.task.DefaultTaskFactoryImpl;
@@ -51,6 +52,8 @@ public class JqassistantExecutor implements JqassistantWorker {
             try {
                 Main main = new Main(taskFactory);
                 main.run(spec.getArgs().toArray(new String[0]));
+            } catch (CliRuleViolationException e) {
+                throw new RuntimeException(e);
             } catch (Exception e) {
                 LOGGER.error("Error while executing jQAssistant: " + e, e);
             }


### PR DESCRIPTION
I'd expect the jQAssistant plugin to fail the build in case jQAssistant has detected a violation of a rule. This way the the jQAssistant Gradle plugin is more useful in CI setups, which use build failures to inform developers that their branch needs rework. I think this works the same with the jQAssistent Maven plugin.
To this end, we rethrow `CliRuleViolationException` instead of just logging it. In case of rule violations, we trade a successful build for a build failure with the following output:

>\> Task :analyze FAILED
>
>FAILURE: Build failed with an exception.
>
>\* What went wrong:
>Execution failed for task ':analyze'.
>\> com.buschmais.jqassistant.commandline.CliRuleViolationException: Failed rules detected: 0 concepts, 1 constraints
>
>\* Try:
>Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
>
>\* Get more help at https://help.gradle.org
>
>BUILD FAILED in 1m 33s
>16 actionable tasks: 14 executed, 2 up-to-date




